### PR TITLE
common: do not use sudo inside common installation scripts

### DIFF
--- a/utils/docker/images/install-cmocka.sh
+++ b/utils/docker/images/install-cmocka.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 #
@@ -17,7 +17,7 @@ if [ $? -ne 0 ]; then
 	set -e
 	openssl s_client -showcerts -servername git.cryptomilk.org -connect git.cryptomilk.org:443 </dev/null 2>/dev/null \
 		| sed -n -e '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p'  > git-cryptomilk.org.pem
-	cat git-cryptomilk.org.pem | sudo tee -a /etc/ssl/certs/ca-certificates.crt
+	cat git-cryptomilk.org.pem | tee -a /etc/ssl/certs/ca-certificates.crt
 	rm git-cryptomilk.org.pem
 	git clone https://git.cryptomilk.org/projects/cmocka.git
 fi
@@ -31,6 +31,6 @@ git checkout $CMOCKA_VERSION
 
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo
 make -j$(nproc)
-sudo make -j$(nproc) install
+make -j$(nproc) install
 cd ../..
-sudo rm -rf cmocka
+rm -rf cmocka

--- a/utils/docker/images/install-txt2man.sh
+++ b/utils/docker/images/install-txt2man.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 #
@@ -17,6 +17,6 @@ cd txt2man
 git checkout txt2man-1.7.0
 
 make -j$(nproc)
-sudo make -j$(nproc) install prefix=/usr
+make -j$(nproc) install prefix=/usr
 cd ..
 rm -rf txt2man


### PR DESCRIPTION
Do not use `sudo` inside the common installation scripts,
they should be called with `sudo` instead:

$ sudo utils/docker/images/install-cmocka.sh
$ sudo utils/docker/images/install-txt2man.sh

`sudo` can be used in `install-archlinux-aur.sh`,
because this file is specific for Arch Linux.

This patch is required for integration with LGTM.com:

Ref: #1411